### PR TITLE
Add CORS and HTTP methods to Vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,11 @@
   "routes": [
     {
       "src": "/(.*)",
-      "dest": "server.js"
+      "dest": "server.js",
+      "methods": ["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],
+      "headers": {
+        "Access-Control-Allow-Origin": "*"
+      }
     }
   ]
 }


### PR DESCRIPTION
The changes add CORS headers and explicitly define allowed HTTP methods in the Vercel routing configuration.